### PR TITLE
新增b站回复弹幕发送

### DIFF
--- a/live-chat-client-codec/live-chat-client-codec-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/codec/bilibili/api/BilibiliApis.java
+++ b/live-chat-client-codec/live-chat-client-codec-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/codec/bilibili/api/BilibiliApis.java
@@ -359,6 +359,22 @@ public class BilibiliApis {
     }
 
     /**
+     * 发送回复弹幕
+     *
+     * @param msg        内容
+     * @param realRoomId 真实房间id
+     * @param replyUid   被回复用户的uid
+     * @param cookie     Cookie
+     */
+    public static void sendMsg(String msg, long realRoomId, long replyUid, String cookie) {
+        String biliJct = OrLiveChatCookieUtil.getCookieByName(cookie, KEY_COOKIE_CSRF, () -> {
+            throw new BaseException("cookie中缺少参数" + KEY_COOKIE_CSRF);
+        });
+        BilibiliSendMsgRequest request = new BilibiliSendMsgRequest(msg, StrUtil.toString(ZonedDateTime.now(ZoneId.of("Asia/Shanghai")).toEpochSecond()), realRoomId, replyUid, biliJct, biliJct);
+        sendMsg(request, cookie);
+    }
+
+    /**
      * 为主播点赞
      *
      * @param request {@link BilibiliLikeReportV3Request}

--- a/live-chat-client-codec/live-chat-client-codec-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/codec/bilibili/api/BilibiliApis.java
+++ b/live-chat-client-codec/live-chat-client-codec-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/codec/bilibili/api/BilibiliApis.java
@@ -348,21 +348,6 @@ public class BilibiliApis {
      *
      * @param msg        内容
      * @param realRoomId 真实房间id
-     * @param cookie     Cookie
-     */
-    public static void sendMsg(String msg, long realRoomId, String cookie) {
-        String biliJct = OrLiveChatCookieUtil.getCookieByName(cookie, KEY_COOKIE_CSRF, () -> {
-            throw new BaseException("cookie中缺少参数" + KEY_COOKIE_CSRF);
-        });
-        BilibiliSendMsgRequest request = new BilibiliSendMsgRequest(msg, StrUtil.toString(ZonedDateTime.now(ZoneId.of("Asia/Shanghai")).toEpochSecond()), realRoomId, biliJct, biliJct);
-        sendMsg(request, cookie);
-    }
-
-    /**
-     * 发送回复弹幕
-     *
-     * @param msg        内容
-     * @param realRoomId 真实房间id
      * @param replyUid   被回复用户的uid
      * @param cookie     Cookie
      */

--- a/live-chat-client-codec/live-chat-client-codec-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/codec/bilibili/api/request/BilibiliSendMsgRequest.java
+++ b/live-chat-client-codec/live-chat-client-codec-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/codec/bilibili/api/request/BilibiliSendMsgRequest.java
@@ -61,7 +61,7 @@ public class BilibiliSendMsgRequest {
     /**
      * 被回复用户的UID
      */
-    private long reply_mid = 0L;
+    private long reply_mid;
     /**
      * Cookie中的bili_jct
      */
@@ -71,16 +71,12 @@ public class BilibiliSendMsgRequest {
      */
     private String csrf_token;
 
-    public BilibiliSendMsgRequest(String msg, String rnd, long roomid, String csrf, String csrf_token) {
+    public BilibiliSendMsgRequest(String msg, String rnd, long roomid, long reply_mid, String csrf, String csrf_token) {
         this.msg = msg;
         this.rnd = rnd;
         this.roomid = roomid;
+        this.reply_mid = reply_mid;
         this.csrf = csrf;
         this.csrf_token = csrf_token;
-    }
-
-    public BilibiliSendMsgRequest(String msg, String rnd, long roomid, long reply_mid, String csrf, String csrf_token) {
-        this(msg, rnd, roomid, csrf, csrf_token);
-        this.reply_mid = reply_mid;
     }
 }

--- a/live-chat-client-codec/live-chat-client-codec-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/codec/bilibili/api/request/BilibiliSendMsgRequest.java
+++ b/live-chat-client-codec/live-chat-client-codec-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/codec/bilibili/api/request/BilibiliSendMsgRequest.java
@@ -59,6 +59,10 @@ public class BilibiliSendMsgRequest {
      */
     private long roomid;
     /**
+     * 被回复用户的UID
+     */
+    private long reply_mid = 0L;
+    /**
      * Cookie中的bili_jct
      */
     private String csrf;
@@ -73,5 +77,10 @@ public class BilibiliSendMsgRequest {
         this.roomid = roomid;
         this.csrf = csrf;
         this.csrf_token = csrf_token;
+    }
+
+    public BilibiliSendMsgRequest(String msg, String rnd, long roomid, long reply_mid, String csrf, String csrf_token) {
+        this(msg, rnd, roomid, csrf, csrf_token);
+        this.reply_mid = reply_mid;
     }
 }

--- a/live-chat-client-commons/live-chat-client-commons-client/src/main/java/tech/ordinaryroad/live/chat/client/commons/client/request/SendDanmuRequest.java
+++ b/live-chat-client-commons/live-chat-client-commons-client/src/main/java/tech/ordinaryroad/live/chat/client/commons/client/request/SendDanmuRequest.java
@@ -1,0 +1,10 @@
+package tech.ordinaryroad.live.chat.client.commons.client.request;
+
+import lombok.Data;
+
+@Data
+public class SendDanmuRequest {
+    private String msg;
+    private String replyUid;
+    private String replyUsername;
+}

--- a/live-chat-clients/live-chat-client-bilibili/pom.xml
+++ b/live-chat-clients/live-chat-client-bilibili/pom.xml
@@ -56,5 +56,9 @@
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>tech.ordinaryroad</groupId>
+            <artifactId>live-chat-client-commons-client</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/live-chat-clients/live-chat-client-bilibili/pom.xml
+++ b/live-chat-clients/live-chat-client-bilibili/pom.xml
@@ -51,14 +51,15 @@
         </dependency>
 
         <dependency>
+            <groupId>tech.ordinaryroad</groupId>
+            <artifactId>live-chat-client-commons-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>tech.ordinaryroad</groupId>
-            <artifactId>live-chat-client-commons-client</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/live-chat-clients/live-chat-client-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/bilibili/client/BilibiliLiveChatClient.java
+++ b/live-chat-clients/live-chat-client-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/bilibili/client/BilibiliLiveChatClient.java
@@ -148,7 +148,8 @@ public class BilibiliLiveChatClient extends BaseNettyClient<
         return StrUtil.format("wss://{}:{}/sub", hostList.getHost(), hostList.getWss_port());
     }
 
-    public void sendDanmu(Object danmu, long reply, Runnable success, Consumer<Throwable> failed) {
+    @Override
+    public void sendDanmu(Object danmu, Runnable success, Consumer<Throwable> failed) {
         if (!checkCanSendDanmu(false)) {
             return;
         }
@@ -157,6 +158,21 @@ public class BilibiliLiveChatClient extends BaseNettyClient<
             try {
                 if (log.isDebugEnabled()) {
                     log.debug("{} bilibili发送弹幕 {}", getConfig().getRoomId(), danmu);
+                }
+
+                // 正则获取被回复人UID "@reply msg"
+                long reply = 0L;
+                if (msg.startsWith("@")) {
+                    String[] split = msg.split(" ", 2);
+                    if (split.length > 1) {
+                        msg = split[1];
+                        String replyId = split[0].substring(1);
+                        try {
+                            reply = Long.parseLong(replyId);
+                        } catch (NumberFormatException e) {
+                            log.error("解析被回复人UID失败", e);
+                        }
+                    }
                 }
 
                 boolean sendSuccess = false;
@@ -189,11 +205,6 @@ public class BilibiliLiveChatClient extends BaseNettyClient<
         } else {
             super.sendDanmu(danmu, success, failed);
         }
-    }
-
-    @Override
-    public void sendDanmu(Object danmu, Runnable success, Consumer<Throwable> failed) {
-        sendDanmu(danmu, 0L, success, failed);
     }
 
     @Override

--- a/live-chat-clients/live-chat-client-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/bilibili/client/BilibiliLiveChatClient.java
+++ b/live-chat-clients/live-chat-client-bilibili/src/main/java/tech/ordinaryroad/live/chat/client/bilibili/client/BilibiliLiveChatClient.java
@@ -148,8 +148,7 @@ public class BilibiliLiveChatClient extends BaseNettyClient<
         return StrUtil.format("wss://{}:{}/sub", hostList.getHost(), hostList.getWss_port());
     }
 
-    @Override
-    public void sendDanmu(Object danmu, Runnable success, Consumer<Throwable> failed) {
+    public void sendDanmu(Object danmu, long reply, Runnable success, Consumer<Throwable> failed) {
         if (!checkCanSendDanmu(false)) {
             return;
         }
@@ -162,7 +161,7 @@ public class BilibiliLiveChatClient extends BaseNettyClient<
 
                 boolean sendSuccess = false;
                 try {
-                    BilibiliApis.sendMsg(msg, roomInitResult.getRoomPlayInfoResult().getRoom_id(), getConfig().getCookie());
+                    BilibiliApis.sendMsg(msg, roomInitResult.getRoomPlayInfoResult().getRoom_id(), reply, getConfig().getCookie());
                     sendSuccess = true;
                 } catch (Exception e) {
                     log.error("bilibili弹幕发送失败", e);
@@ -190,6 +189,11 @@ public class BilibiliLiveChatClient extends BaseNettyClient<
         } else {
             super.sendDanmu(danmu, success, failed);
         }
+    }
+
+    @Override
+    public void sendDanmu(Object danmu, Runnable success, Consumer<Throwable> failed) {
+        sendDanmu(danmu, 0L, success, failed);
     }
 
     @Override


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [√] 我已阅读并理解[贡献者指南]()。
- [√] 我已检查没有与此请求重复的拉取请求。
- [√] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [√] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

- 在`BilibiliSendMsgRequest`中新增了`reply_mid`参数用于指定回复对象。
- 在`BilibiliApis`中修改了`sendMsg()`方法，用于支持回复弹幕的发送。
- 在`BilibiliLiveChatClient`中，为原`sendDanmu()`中的`Object danmu`设定了格式要求：当满足以字符`@`开头，且字符`@`与字符` `（空格）之间的内容为可解析的长整数时，将此部分内容作为被回复者的UID进行回复弹幕的发送。

**至于为什么要规定这样的格式而不是重载原来的方法呢？**

主要还是考虑到开发者侧调用的是`BaseLiveChatClient`中的方法，而其中已经将
- `sendDanmu(Object danmu)`
- `sendDanmu(Object danmu, Runnable success)`
- `sendDanmu(Object danmu, Consumer<Throwable> failed)`
这三个方法做了处理，所以通过添加方法参数的方式来实现新的回复功能，可能会破坏原来的代码结构

若有更好的实现，希望大家能够不吝赐教🙏